### PR TITLE
Expand stream slot ids to 32 bit

### DIFF
--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -190,7 +190,7 @@ using ip_address = ipv6_address;
 using ip_endpoint = ipv6_endpoint;
 using ip_subnet = ipv6_subnet;
 using settings = dictionary<config_value>;
-using stream_slot = uint16_t;
+using stream_slot = uint32_t;
 
 // -- functions ----------------------------------------------------------------
 

--- a/libcaf_core/caf/stream_slot.hpp
+++ b/libcaf_core/caf/stream_slot.hpp
@@ -26,7 +26,7 @@ namespace caf {
 
 /// Identifies a single stream path in the same way a TCP port identifies a
 /// connection over IP.
-using stream_slot = uint16_t;
+using stream_slot = uint32_t;
 
 /// Identifies an invalid slot.
 constexpr stream_slot invalid_stream_slot = 0;


### PR DESCRIPTION
In a load testing scenario, we observed that an overflow in the
stream slot ids could lead to a deadlocked VAST binary which
was spinning at 100% cpu while unable to process any input.

This overflow would happen after around 1 day of heavy-duty
usage of VAST.

This change is a workaround to buy more time until the overflow
occurs; until we can find a permanent solution to the issue.