### PR TITLE
Print actor id when adjusting running count

### DIFF
--- a/libcaf_core/caf/actor_registry.hpp
+++ b/libcaf_core/caf/actor_registry.hpp
@@ -64,10 +64,10 @@ public:
   void erase(actor_id key);
 
   /// Increases running-actors-count by one.
-  void inc_running();
+  void inc_running(actor_id actor);
 
   /// Decreases running-actors-count by one.
-  void dec_running();
+  void dec_running(actor_id actor);
 
   /// Returns the number of currently running actors.
   size_t running() const;

--- a/libcaf_core/src/abstract_actor.cpp
+++ b/libcaf_core/src/abstract_actor.cpp
@@ -97,14 +97,14 @@ void abstract_actor::register_at_system() {
   if (getf(is_registered_flag))
     return;
   setf(is_registered_flag);
-  home_system().registry().inc_running();
+  home_system().registry().inc_running(id());
 }
 
 void abstract_actor::unregister_from_system() {
   if (!getf(is_registered_flag))
     return;
   unsetf(is_registered_flag);
-  home_system().registry().dec_running();
+  home_system().registry().dec_running(id());
 }
 
 } // namespace caf

--- a/libcaf_core/src/actor_registry.cpp
+++ b/libcaf_core/src/actor_registry.cpp
@@ -35,6 +35,7 @@
 #include "caf/event_based_actor.hpp"
 #include "caf/uniform_type_info_map.hpp"
 
+#include "caf/detail/attributes.hpp"
 #include "caf/detail/shared_spinlock.hpp"
 
 namespace caf {
@@ -96,26 +97,22 @@ void actor_registry::erase(actor_id key) {
   }
 }
 
-void actor_registry::inc_running() {
-# if CAF_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
-  auto value = ++running_;
-  CAF_LOG_DEBUG(CAF_ARG(value));
-# else
-  ++running_;
-# endif
+void actor_registry::inc_running([[maybe_unused]] actor_id actor) {
+  [[maybe_unused]] auto value = ++running_;
+  CAF_LOG_DEBUG("inc running count from actor " << actor << " to " << value);
 }
 
 size_t actor_registry::running() const {
   return running_.load();
 }
 
-void actor_registry::dec_running() {
+void actor_registry::dec_running([[maybe_unused]] actor_id actor) {
   size_t new_val = --running_;
   if (new_val <= 1) {
     std::unique_lock<std::mutex> guard(running_mtx_);
     running_cv_.notify_all();
   }
-  CAF_LOG_DEBUG(CAF_ARG(new_val));
+  CAF_LOG_DEBUG("dec running count from actor " << actor << " to " << new_val);
 }
 
 void actor_registry::await_running_count_equal(size_t expected) const {


### PR DESCRIPTION
Add a debug statements printing the actor id whenever the running actor count is adjusted.

This speeds up debugging for errors where the running count does not reach zero at program shutdown but it is not clear which actor is still alive.