### PR TITLE
Fix container overflow reported by ASan

### DIFF
--- a/libcaf_core/src/detail/get_mac_addresses.cpp
+++ b/libcaf_core/src/detail/get_mac_addresses.cpp
@@ -87,7 +87,7 @@ std::vector<iface_info> get_mac_addresses() {
     }
     auto addr = oss.str();
     if (addr != "00:00:00:00:00:00") {
-      result.emplace_back(i->if_name, std::move(addr));
+      result.push_back({i->if_name, std::move(addr)});
     }
   }
   if_freenameindex(indices);


### PR DESCRIPTION
This fixes an ASan container overflow for macOS in Debug builds. We ran into this previously for the unit test suite only, but after updating my OS I now get this even for VAST itself in Debug builds. This fixes the container overflow, but admittedly I don't understand why. Maybe it's just a bug in ASan. :shrug: