### PR TITLE
Use 32 bit values for stream slots

### DIFF
--- a/libcaf_core/caf/fwd.hpp
+++ b/libcaf_core/caf/fwd.hpp
@@ -198,7 +198,7 @@ using ip_endpoint = ipv6_endpoint;
 using ip_subnet = ipv6_subnet;
 using settings = dictionary<config_value>;
 using skippable_result = variant<delegated<message>, message, error, skip_t>;
-using stream_slot = uint16_t;
+using stream_slot = uint32_t;
 using type_id_t = uint16_t;
 
 // -- functions ----------------------------------------------------------------

--- a/libcaf_core/caf/stream_slot.hpp
+++ b/libcaf_core/caf/stream_slot.hpp
@@ -13,7 +13,7 @@ namespace caf {
 
 /// Identifies a single stream path in the same way a TCP port identifies a
 /// connection over IP.
-using stream_slot = uint16_t;
+using stream_slot = uint32_t;
 
 /// Identifies an invalid slot.
 constexpr stream_slot invalid_stream_slot = 0;


### PR DESCRIPTION
We observed some strange streaming behavior when the stream slot assignment wraps around the maximum value. By increasing the number of slots to a value that we won't hit for a long time we effectively work around this problem.