### PR TITLE
Include missing <cstdint> header to fix gcc>13 builds

### DIFF
--- a/libcaf_core/caf/detail/ripemd_160.hpp
+++ b/libcaf_core/caf/detail/ripemd_160.hpp
@@ -41,6 +41,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 #include "caf/detail/core_export.hpp"
@@ -48,7 +49,7 @@
 namespace caf::detail {
 
 /// Creates a hash from `data` using the RIPEMD-160 algorithm.
-CAF_CORE_EXPORT void
-ripemd_160(std::array<uint8_t, 20>& storage, const std::string& data);
+CAF_CORE_EXPORT void ripemd_160(std::array<uint8_t, 20>& storage,
+                                const std::string& data);
 
 } // namespace caf::detail


### PR DESCRIPTION
This change prevents Tenzir from not building correctly due to some changes in `gcc>13` versions requiring a new header to be included.