### PR TITLE
Fix unbounded attachable growth when monitoring actors exit

### DIFF
--- a/libcaf_core/caf/actor_system.cpp
+++ b/libcaf_core/caf/actor_system.cpp
@@ -465,7 +465,12 @@ public:
     }
     // Make sure we have a clock.
     if (!clock) {
-      clock = std::make_unique<actor_clock_impl>(*parent);
+      auto& factory = cfg.get_clock_factory();
+      if (factory) {
+        clock = factory(*parent);
+      } else {
+        clock = std::make_unique<actor_clock_impl>(*parent);
+      }
     }
     // Make sure we have a scheduler up and running.
     if (!scheduler) {

--- a/libcaf_core/caf/actor_system_config.cpp
+++ b/libcaf_core/caf/actor_system_config.cpp
@@ -4,6 +4,7 @@
 
 #include "caf/actor_system_config.hpp"
 
+#include "caf/actor_clock.hpp"
 #include "caf/config.hpp"
 #include "caf/config_option.hpp"
 #include "caf/config_option_adder.hpp"
@@ -101,6 +102,8 @@ struct actor_system_config::fields {
   exception_handler_type exception_handler
     = scheduled_actor::default_exception_handler;
 #endif // CAF_ENABLE_EXCEPTIONS
+  std::function<auto(actor_system&)->std::unique_ptr<actor_clock>>
+    clock_factory;
 };
 
 // -- constructors, destructors, and assignment operators ----------------------
@@ -617,6 +620,16 @@ void actor_system_config::print_content() const {
   config_printer printer;
   printer(dump_content());
   std::cout << std::endl;
+}
+
+void actor_system_config::set_clock_factory(
+  std::function<auto(actor_system&)->std::unique_ptr<actor_clock>> clock) {
+  fields_->clock_factory = std::move(clock);
+}
+
+auto actor_system_config::get_clock_factory() const
+  -> std::function<auto(actor_system&)->std::unique_ptr<actor_clock>>& {
+  return fields_->clock_factory;
 }
 
 // -- module factories ---------------------------------------------------------

--- a/libcaf_core/caf/actor_system_config.hpp
+++ b/libcaf_core/caf/actor_system_config.hpp
@@ -258,6 +258,12 @@ public:
   /// @private
   void print_content() const;
 
+  void set_clock_factory(
+    std::function<auto(actor_system&)->std::unique_ptr<actor_clock>> clock);
+
+  auto get_clock_factory() const
+    -> std::function<auto(actor_system&)->std::unique_ptr<actor_clock>>&;
+
 protected:
   config_option_set custom_options_;
 

--- a/libcaf_core/caf/actor_traits.hpp
+++ b/libcaf_core/caf/actor_traits.hpp
@@ -96,10 +96,4 @@ template <class T>
 struct actor_traits
   : default_actor_traits<T, std::is_base_of_v<abstract_actor, T>> {};
 
-template <class T>
-concept blocking_actor_type = actor_traits<T>::is_blocking;
-
-template <class T>
-concept non_blocking_actor_type = actor_traits<T>::is_non_blocking;
-
 } // namespace caf

--- a/libcaf_core/caf/attachable.hpp
+++ b/libcaf_core/caf/attachable.hpp
@@ -35,6 +35,9 @@ public:
     /// Identifies `default_attachable::observe_token`.
     static constexpr size_t observer = 2;
 
+    /// Identifies `detail::monitor_token`.
+    static constexpr size_t monitor = 3;
+
     template <class T>
     token(const T& tk) : subtype(T::token_type), ptr(&tk) {
       // nop

--- a/libcaf_core/caf/behavior.hpp
+++ b/libcaf_core/caf/behavior.hpp
@@ -37,11 +37,6 @@ public:
     // nop
   }
 
-  // Convenience overload to allow "unsafe" initialization of any behavior_type.
-  explicit behavior(unsafe_behavior_init_t) {
-    // nop
-  }
-
   /// Creates a behavior from `fun` without timeout.
   behavior(const message_handler& mh);
 

--- a/libcaf_core/caf/blocking_actor.cpp
+++ b/libcaf_core/caf/blocking_actor.cpp
@@ -175,7 +175,8 @@ void blocking_actor::await_all_other_actors_done() {
 
 void blocking_actor::act() {
   auto lg = log::core::trace("");
-  // Default implementation does nothing.
+  if (initial_behavior_fac_)
+    initial_behavior_fac_(this);
 }
 
 void blocking_actor::fail_state(error err) {

--- a/libcaf_core/caf/detail/monitor_attachable.hpp
+++ b/libcaf_core/caf/detail/monitor_attachable.hpp
@@ -1,0 +1,53 @@
+// This file is part of CAF, the C++ Actor Framework. See the file LICENSE in
+// the main distribution directory for license terms and copyright or visit
+// https://github.com/actor-framework/actor-framework/blob/main/LICENSE.
+
+#pragma once
+
+#include "caf/action.hpp"
+#include "caf/actor.hpp"
+#include "caf/actor_addr.hpp"
+#include "caf/actor_cast.hpp"
+#include "caf/attachable.hpp"
+#include "caf/detail/monitor_action.hpp"
+#include "caf/mailbox_element.hpp"
+
+namespace caf::detail {
+
+/// Token used to identify and remove a `monitor_attachable` via `detach()`.
+struct monitor_token {
+  abstract_monitor_action* key;
+  static constexpr size_t token_type = attachable::token::monitor;
+};
+
+/// Attachable placed on the monitored actor. Unlike `functor_attachable` it
+/// carries a matchable token so it can be removed via `abstract_actor::detach()`
+/// when the monitoring actor exits or cancels the monitor.
+class monitor_attachable : public attachable {
+public:
+  static constexpr size_t token_type = attachable::token::monitor;
+
+  monitor_attachable(abstract_monitor_action_ptr on_down, actor_addr self)
+    : on_down_(std::move(on_down)), self_(std::move(self)) {}
+
+  void actor_exited(const error& reason, scheduler* sched) override {
+    if (on_down_->set_reason(error{reason})) {
+      if (auto shdl = actor_cast<actor>(self_))
+        shdl->enqueue(
+          make_mailbox_element(nullptr, make_message_id(), action{on_down_}),
+          sched);
+    }
+  }
+
+  bool matches(const token& what) override {
+    if (what.subtype != token_type)
+      return false;
+    return static_cast<const monitor_token*>(what.ptr)->key == on_down_.get();
+  }
+
+private:
+  abstract_monitor_action_ptr on_down_;
+  actor_addr self_;
+};
+
+} // namespace caf::detail

--- a/libcaf_core/caf/local_actor.cpp
+++ b/libcaf_core/caf/local_actor.cpp
@@ -73,9 +73,11 @@ void local_actor::demonitor(const node_id& node) {
 }
 
 void local_actor::do_monitor(abstract_actor* ptr, message_priority priority) {
-  if (ptr != nullptr)
+  if (ptr != nullptr) {
     ptr->attach(
       default_attachable::make_monitor(ptr->address(), address(), priority));
+    monitored_actors_.emplace_back(ptr->ctrl(), add_ref);
+  }
 }
 
 void local_actor::do_demonitor(const strong_actor_ptr& whom) {
@@ -137,6 +139,10 @@ void local_actor::on_cleanup([[maybe_unused]] const error& reason) {
   if (auto* running_count = metrics_.running_count) {
     running_count->dec();
   }
+  for (auto& weak : monitored_actors_)
+    if (auto ptr = weak.lock())
+      do_demonitor(ptr);
+  monitored_actors_.clear();
   on_exit();
   CAF_LOG_TERMINATE_EVENT(this, reason);
 }

--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -35,6 +35,7 @@
 #include <cstdint>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace caf {
 
@@ -381,6 +382,10 @@ protected:
 
   /// Stores the metrics for this actor.
   telemetry::actor_metrics metrics_;
+
+  /// Tracks actors monitored via the non-callback monitor() API so they can
+  /// be demonitored automatically when this actor exits.
+  std::vector<weak_actor_ptr> monitored_actors_;
 
 private:
   virtual void do_unstash(mailbox_element_ptr ptr) = 0;

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -11,6 +11,7 @@
 #include "caf/config.hpp"
 #include "caf/defaults.hpp"
 #include "caf/detail/assert.hpp"
+#include "caf/detail/monitor_attachable.hpp"
 #include "caf/detail/critical.hpp"
 #include "caf/detail/current_actor.hpp"
 #include "caf/detail/default_invoke_result_visitor.hpp"
@@ -29,6 +30,51 @@
 #include "caf/telemetry/metric_family_impl.hpp"
 
 using namespace std::string_literals;
+
+namespace {
+
+/// Disposable returned from do_monitor. Calling dispose() both cancels the
+/// monitor_action and removes its monitor_attachable from the monitored actor,
+/// so the monitored actor's attachable list never accumulates stale entries.
+class monitor_disposable_impl : public caf::ref_counted,
+                                public caf::disposable::impl {
+public:
+  monitor_disposable_impl(caf::detail::abstract_monitor_action_ptr on_down,
+                          caf::weak_actor_ptr monitored)
+    : on_down_(std::move(on_down)), monitored_(std::move(monitored)) {}
+
+  void dispose() override {
+    on_down_->dispose();
+    if (auto ptr = monitored_.lock())
+      ptr->get()->detach(caf::detail::monitor_token{on_down_.get()});
+  }
+
+  bool disposed() const noexcept override {
+    return on_down_->disposed();
+  }
+
+  void ref_disposable() const noexcept override {
+    ref();
+  }
+
+  void deref_disposable() const noexcept override {
+    deref();
+  }
+
+  friend void intrusive_ptr_add_ref(const monitor_disposable_impl* p) noexcept {
+    p->ref();
+  }
+
+  friend void intrusive_ptr_release(const monitor_disposable_impl* p) noexcept {
+    p->deref();
+  }
+
+private:
+  caf::detail::abstract_monitor_action_ptr on_down_;
+  caf::weak_actor_ptr monitored_;
+};
+
+} // namespace
 
 namespace caf {
 
@@ -246,6 +292,11 @@ void scheduled_actor::on_cleanup(const error& reason) {
   // Shutdown hosting thread when running detached.
   if (private_thread_)
     home_system().release_private_thread(private_thread_);
+  // Cancel any monitors this actor set up to avoid leaving stale attachables
+  // in the monitored actors' lists.
+  for (auto& d : active_monitors_)
+    d.dispose();
+  active_monitors_.clear();
   // Clear state for open requests, flows and streams.
   awaited_responses_.clear();
   multiplexed_responses_.clear();
@@ -1139,6 +1190,7 @@ void scheduled_actor::update_watched_disposables() {
     log::core::debug("now watching {} disposables",
                      watched_disposables_.size());
   }
+  disposable::erase_disposed(active_monitors_);
 }
 
 void scheduled_actor::register_flow_state(uint64_t local_id,
@@ -1219,16 +1271,13 @@ scheduled_actor::do_monitor(abstract_actor* ptr,
                             detail::abstract_monitor_action_ptr on_down) {
   if (ptr == nullptr)
     return {};
-  ptr->attach_functor([self = address(), on_down](error reason) {
-    // Failing to set the arg means the action was disposed.
-    if (on_down->set_reason(std::move(reason))) {
-      if (auto shdl = actor_cast<actor>(self))
-        shdl->enqueue(make_mailbox_element(nullptr, make_message_id(),
-                                           action{on_down}),
-                      nullptr);
-    }
-  });
-  return on_down->as_disposable();
+  ptr->attach(attachable_ptr{
+    new detail::monitor_attachable(on_down, address())});
+  auto d = disposable{
+    make_counted<monitor_disposable_impl>(on_down,
+                                         actor_cast<weak_actor_ptr>(ptr))};
+  active_monitors_.push_back(d);
+  return d;
 }
 
 } // namespace caf

--- a/libcaf_core/caf/scheduled_actor.cpp
+++ b/libcaf_core/caf/scheduled_actor.cpp
@@ -324,6 +324,10 @@ void scheduled_actor::resume(scheduler* sched, uint64_t event_id) {
   // time's up
   log::core::debug("max throughput reached: resume later");
   intrusive_ptr_add_ref(ctrl());
+  if (private_thread_ != nullptr) {
+    private_thread_->resume(this);
+    return;
+  }
   sched->delay(this, resumable::default_event_id);
 }
 

--- a/libcaf_core/caf/scheduled_actor.hpp
+++ b/libcaf_core/caf/scheduled_actor.hpp
@@ -854,6 +854,11 @@ private:
   /// terminating.
   std::vector<disposable> watched_disposables_;
 
+  /// Stores disposables for active monitors set up by this actor. Disposed
+  /// automatically in on_cleanup() so stale entries never accumulate on the
+  /// monitored actors' attachable lists.
+  std::vector<disposable> active_monitors_;
+
   /// Stores open streams that other actors may access. An actor is considered
   /// alive as long as it has open streams.
   std::unordered_map<uint64_t, stream_source_state> stream_sources_;

--- a/libcaf_core/caf/stateful_actor.hpp
+++ b/libcaf_core/caf/stateful_actor.hpp
@@ -4,16 +4,12 @@
 
 #pragma once
 
-#include "caf/actor_traits.hpp"
-#include "caf/behavior.hpp"
-#include "caf/callback.hpp"
 #include "caf/detail/concepts.hpp"
-#include "caf/detail/metaprogramming.hpp"
 #include "caf/fwd.hpp"
+#include "caf/sec.hpp"
 #include "caf/unsafe_behavior_init.hpp"
 
 #include <new>
-#include <tuple>
 #include <type_traits>
 
 namespace caf::detail {
@@ -28,37 +24,12 @@ public:
   typename Base::behavior_type make_behavior() override;
 };
 
-/// Conditional base type for `stateful_actor` that overrides `act` when using a
-/// blocking actor as base.
+/// Evaluates to either `stateful_actor_base<State, Base> `or `Base`, depending
+/// on whether `State::make_behavior()` exists.
 template <class State, class Base>
-class stateful_blocking_actor_base : public Base {
-public:
-  using Base::Base;
-
-  void act() override;
-};
-
-template <class State, class Base>
-struct stateful_actor_base_oracle {
-  using type = Base;
-};
-
-template <has_make_behavior State, non_blocking_actor_type Base>
-struct stateful_actor_base_oracle<State, Base> {
-  using type = stateful_actor_base<State, Base>;
-};
-
-template <has_make_behavior State, blocking_actor_type Base>
-struct stateful_actor_base_oracle<State, Base> {
-  using type = stateful_blocking_actor_base<State, Base>;
-};
-
-/// Evaluates to either `stateful_actor_base<State, Base>`,
-/// `stateful_blocking_actor_base<State, Base>`, or `Base`, depending on whether
-/// the state has `make_behavior()` and whether the base is a blocking actor.
-template <class State, class Base>
-using stateful_actor_base_t =
-  typename stateful_actor_base_oracle<State, Base>::type;
+using stateful_actor_base_t
+  = std::conditional_t<has_make_behavior<State>,
+                       stateful_actor_base<State, Base>, Base>;
 
 } // namespace caf::detail
 
@@ -124,75 +95,15 @@ namespace caf::detail {
 
 template <class State, class Base>
 typename Base::behavior_type stateful_actor_base<State, Base>::make_behavior() {
+  // When spawning function-based actors, CAF sets `initial_behavior_fac_` to
+  // wrap the function invocation. This always has the highest priority.
+  if (this->initial_behavior_fac_) {
+    auto res = this->initial_behavior_fac_(this);
+    this->initial_behavior_fac_ = nullptr;
+    return {unsafe_behavior_init, std::move(res)};
+  }
   auto dptr = static_cast<stateful_actor<State, Base>*>(this);
   return dptr->state().make_behavior();
 }
-
-template <class State, class Base>
-void stateful_blocking_actor_base<State, Base>::act() {
-  // We call `make_behavior()` only to invoke the user-defined callback. For
-  // blocking actors, this callback must return `void` and `make_behavior()`
-  // will thus always return a default-constructed (empty) behavior that we can
-  // safely discard.
-  auto dptr = static_cast<stateful_actor<State, Base>*>(this);
-  std::ignore = dptr->state().make_behavior();
-}
-
-template <class Self>
-struct functor_state {
-  using behavior_type = typename Self::behavior_type;
-
-  template <class Fn, class... Args>
-  explicit functor_state(Self* selfptr, Fn&& f, Args&&... args)
-    : self(selfptr) {
-    // Wrap the function invocation into a callback that we can call later in
-    // `make_behavior()` when launching the actor.
-    if constexpr (std::is_invocable_r_v<behavior_type, Fn, Self*, Args...>) {
-      static_assert(!actor_traits<Self>::is_blocking,
-                    "Blocking actors cannot return a behavior");
-      auto g = [f = std::forward<Fn>(f), ... args = std::forward<Args>(args)](
-                 Self* self) mutable -> behavior_type {
-        return f(self, std::move(args)...);
-      };
-      fn = make_type_erased_callback(std::move(g));
-    } else if constexpr (std::is_invocable_r_v<behavior_type, Fn, Args...>) {
-      static_assert(!actor_traits<Self>::is_blocking,
-                    "Blocking actors cannot return a behavior");
-      auto g = [f = std::forward<Fn>(f), ... args = std::forward<Args>(args)](
-                 Self*) mutable -> behavior_type {
-        return f(std::move(args)...);
-      };
-      fn = make_type_erased_callback(std::move(g));
-    } else if constexpr (std::is_invocable_r_v<void, Fn, Self*, Args...>) {
-      auto g = [f = std::forward<Fn>(f), ... args = std::forward<Args>(args)](
-                 Self* self) mutable -> behavior_type {
-        f(self, std::move(args)...);
-        return behavior_type{unsafe_behavior_init};
-      };
-      fn = make_type_erased_callback(std::move(g));
-    } else if constexpr (std::is_invocable_r_v<void, Fn, Args...>) {
-      auto g = [f = std::forward<Fn>(f), ... args = std::forward<Args>(args)](
-                 Self*) mutable -> behavior_type {
-        f(std::move(args)...);
-        return behavior_type{unsafe_behavior_init};
-      };
-      fn = make_type_erased_callback(std::move(g));
-    } else {
-      static_assert(detail::always_false<Fn>, "Invalid callable type");
-    }
-  }
-
-  behavior_type make_behavior() {
-    if (fn) {
-      auto res = (*fn)(self);
-      fn = nullptr;
-      return res;
-    }
-    return behavior_type{unsafe_behavior_init};
-  }
-
-  Self* self;
-  unique_callback_ptr<behavior_type(Self*)> fn;
-};
 
 } // namespace caf::detail

--- a/libcaf_core/caf/typed_behavior.hpp
+++ b/libcaf_core/caf/typed_behavior.hpp
@@ -186,10 +186,6 @@ public:
     // TODO: implement type checking.
   }
 
-  explicit typed_behavior(unsafe_behavior_init_t) {
-    // nop
-  }
-
   typed_behavior(unsafe_behavior_init_t, behavior x) : bhvr_(std::move(x)) {
     // nop
   }

--- a/libcaf_io/caf/io/broker.hpp
+++ b/libcaf_io/caf/io/broker.hpp
@@ -10,7 +10,6 @@
 #include "caf/io/scribe.hpp"
 
 #include "caf/detail/assert.hpp"
-#include "caf/detail/init_fun_factory.hpp"
 #include "caf/detail/io_export.hpp"
 #include "caf/dynamically_typed.hpp"
 #include "caf/extend.hpp"


### PR DESCRIPTION
## Problem

Two separate code paths in CAF's monitor implementation had the same fundamental flaw: when a monitoring actor exits before the monitored actor, stale entries accumulated in the monitored actor's attachable list and kept the monitoring actor's `actor_control_block` alive indefinitely.

**New callback API** (`monitor(whom, fn)` → `scheduled_actor::do_monitor`): used a `functor_attachable` with `token::anonymous`, which `detach()` can never match. So even calling `dispose()` on the returned handle couldn't remove the entry. The `actor_addr` capture kept the control block alive.

**Legacy API** (`monitor(whom)` → `local_actor::do_monitor`): used `default_attachable`, which *is* detachable via `do_demonitor()` — but nothing ever called it on actor exit. Same unbounded growth and control block leak resulted.

**Concrete manifestation**: `tenzir::async_mail` creates a temporary `actor_companion` per request and calls `companion->monitor(receiver)` (legacy API) on the long-lived receiver. Each companion exits after receiving its response but left a permanent stale `default_attachable` in the receiver's list. Under sustained `async_mail` traffic against a single actor this caused unbounded memory growth.

## Solution

**New callback API** (`scheduled_actor`):
- Add `token::monitor = 3` to `attachable::token`.
- Introduce `detail::monitor_attachable`: a detachable attachable keyed by `abstract_monitor_action*`, replacing the anonymous `functor_attachable`.
- Introduce `monitor_disposable_impl`: `dispose()` cancels the action **and** calls `detach()` on the monitored actor via a `weak_actor_ptr`.
- `scheduled_actor` tracks active monitors in `active_monitors_`; `on_cleanup()` disposes all of them automatically.

**Legacy API** (`local_actor`):
- Track each monitored actor as a `weak_actor_ptr` in `local_actor::monitored_actors_`.
- In `on_cleanup()`, lock each entry and call `do_demonitor()` to detach the stale `default_attachable`. Dead entries (lock returns null) are skipped safely.

## Review

For the new API: start in `detail/monitor_attachable.hpp`, then `scheduled_actor.cpp` for `monitor_disposable_impl` and the rewritten `do_monitor`.

For the legacy API: `local_actor.cpp` — `do_monitor` and `on_cleanup` are the only changes, plus `monitored_actors_` in the header.

Race safety: `actor_exited` is called after the monitored actor releases its mutex (see `abstract_actor::cleanup`), so calling `detach()` from `on_cleanup` cannot deadlock. Concurrent exits are safe: `detach()` on an already-swept list is a benign no-op; `set_reason()` on an already-disposed action returns false, preventing double-delivery.
